### PR TITLE
Add BWB cleaning script

### DIFF
--- a/clean_bwb.py
+++ b/clean_bwb.py
@@ -1,0 +1,33 @@
+import re
+from datasets import load_dataset, DatasetDict
+from datasets import Dataset
+from huggingface_hub import HfApi
+
+
+def strip_xml(text: str) -> str:
+    """Remove XML tags from text."""
+    # simple regex to drop tags
+    return re.sub(r"<[^>]+>", "", text)
+
+
+def main():
+    # load original dataset
+    dataset = load_dataset("vGassen/Dutch-Basisbestandwetten-Legislation-Laws", split="train")
+
+    # transform dataset by stripping XML tags
+    cleaned_content = [strip_xml(row["content"]) for row in dataset]
+
+    cleaned_dataset = Dataset.from_dict({
+        "url": dataset["url"],
+        "content": cleaned_content,
+        "source": ["Basiswettenbestand"] * len(dataset),
+    })
+
+    cleaned_dataset = DatasetDict({"train": cleaned_dataset})
+
+    # push to new repository (replace with your repo)
+    cleaned_dataset.push_to_hub("your-username/clean-basiswettenbestand")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-
+datasets
+huggingface_hub


### PR DESCRIPTION
## Summary
- add simple script to load XML dataset from HF, strip tags, and push cleaned data
- add requirements for `datasets` and `huggingface_hub`

## Testing
- `python -m py_compile clean_bwb.py`
- `pip install datasets huggingface_hub --quiet` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68540be763a883298902602692e61bde