### PR TITLE
Add workflow and token login

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,0 +1,19 @@
+name: Clean BWB dataset
+
+on:
+  workflow_dispatch:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run cleaning script
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: python clean_bwb.py

--- a/clean_bwb.py
+++ b/clean_bwb.py
@@ -1,0 +1,38 @@
+import re
+from datasets import load_dataset, DatasetDict
+from datasets import Dataset
+import os
+from huggingface_hub import HfApi, login
+
+
+def strip_xml(text: str) -> str:
+    """Remove XML tags from text."""
+    # simple regex to drop tags
+    return re.sub(r"<[^>]+>", "", text)
+
+
+def main():
+    # load original dataset
+    dataset = load_dataset("vGassen/Dutch-Basisbestandwetten-Legislation-Laws", split="train")
+
+    # transform dataset by stripping XML tags
+    cleaned_content = [strip_xml(row["content"]) for row in dataset]
+
+    cleaned_dataset = Dataset.from_dict({
+        "url": dataset["url"],
+        "content": cleaned_content,
+        "source": ["Basiswettenbestand"] * len(dataset),
+    })
+
+    cleaned_dataset = DatasetDict({"train": cleaned_dataset})
+
+    # push to new repository
+    repo_id = "vGassen/Dutch-Basisbestandwetten-Legislation-Laws-XML-Clean"
+    token = os.environ.get("HF_TOKEN")
+    if token:
+        login(token=token)
+    cleaned_dataset.push_to_hub(repo_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-
+datasets
+huggingface_hub


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run cleaning script
- login with `HF_TOKEN` and push to `vGassen/Dutch-Basisbestandwetten-Legislation-Laws-XML-Clean`

## Testing
- `python -m py_compile clean_bwb.py`

------
https://chatgpt.com/codex/tasks/task_e_68540be763a883298902602692e61bde