### PR TITLE
Filter manifest and WTI files when uploading

### DIFF
--- a/clean_bwb.py
+++ b/clean_bwb.py
@@ -29,11 +29,20 @@ def main() -> None:
     buffer = []
     shard_idx = 0
 
+    skip_suffixes = ("manifest.xml", ".WTI")
+
     for record in dataset:
+        url = record.get("url") or ""
+        if url.lower().endswith(skip_suffixes):
+            continue
+
         raw_text = record.get("content") or record.get("text", "")
+        if not raw_text.strip():
+            continue
+
         buffer.append(
             {
-                "url": record.get("url"),
+                "url": url,
                 "content": strip_xml(raw_text),
                 "source": "Basiswettenbestand",
             }


### PR DESCRIPTION
## Summary
- skip files ending in `manifest.xml` or `.WTI`
- ignore records with empty text

## Testing
- `python -m py_compile clean_bwb.py`

------
https://chatgpt.com/codex/tasks/task_e_6857160f6b7883299b07965b16070a98