### PR TITLE
Skip index records without XML

### DIFF
--- a/clean_bwb.py
+++ b/clean_bwb.py
@@ -55,6 +55,9 @@ def main() -> None:
         raw_text = record.get("content") or record.get("text", "")
         if not raw_text.strip():
             continue
+        if not raw_text.lstrip().startswith("<"):
+            # Skip non-XML records such as index entries.
+            continue
 
         buffer.append(
             {


### PR DESCRIPTION
## Summary
- filter out index-like records that do not contain XML

## Testing
- `python -m py_compile clean_bwb.py`

------
https://chatgpt.com/codex/tasks/task_e_6860422be490832988975c3ff5a77df4